### PR TITLE
BREAKING CHANGE: Use `@sonatype/ossindex-api-client`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 [![CircleCI](https://circleci.com/gh/sonatype-nexus-community/js-sona-types.svg?style=svg)](https://circleci.com/gh/sonatype-nexus-community/js-sona-types)
 
-Hi, hello! This library is mostly for consumption by Sonatype projects that need a common way to talk to OSS Index, Nexus IQ, and etc...
+Hi, hello! This library is mostly for consumption by Sonatype projects that need a common way to talk to OSS Index and Sonatype IQ Server.
 
 ## Goals 
 
-`js-sona-types` is just a library, meant to be used by our JavaScript/TypeScript projects so that we can share some common code around communicating with OSS Index, Nexus IQ Server, etc...
+`js-sona-types` is just a library, meant to be used by our JavaScript/TypeScript projects so that we can share some common code around communicating with OSS Index, Sonatype IQ Server, etc...
 
 Since we also include examples, there are a few living breathing sub projects that show how to use it.
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,5 +9,7 @@ module.exports = {
     'ts-jest': {
       tsconfig: 'tsconfig.test.json'
     }  
-  }
+  },
+  automock: false,
+  setupFiles: ["./setupJest.js"]
 };

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
+    "@sonatype/ossindex-api-client": "^2023.5.2",
     "browser-cookies": "^1.2.0",
     "cross-fetch": "3.1.5",
     "dependency-graph": "^0.11.0",
@@ -60,6 +61,7 @@
     "eslint": "^8.35.0",
     "eslint-plugin-prettier": "^4.2.1",
     "jest": "^27.0.1",
+    "jest-fetch-mock": "^3.0.3",
     "node-persist": "^3.1.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.3.2",

--- a/setupJest.js
+++ b/setupJest.js
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2021-Present Sonatype Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+global.fetch = require('jest-fetch-mock');

--- a/src/OSSIndexRequestService.test.ts
+++ b/src/OSSIndexRequestService.test.ts
@@ -25,7 +25,7 @@ import { Response } from 'cross-fetch';
 const PATH = join(homedir(), '.ossindex', 'js-sona-types-test');
 const TWELVE_HOURS = 12 * 60 * 60 * 1000;
 
-describe.skip('OSS Index Request Service', () => {
+describe('OSS Index Request Service', () => {
   let service: OSSIndexRequestService;
 
   beforeEach(async () => {

--- a/src/OSSIndexRequestService.test.ts
+++ b/src/OSSIndexRequestService.test.ts
@@ -25,7 +25,7 @@ import { Response } from 'cross-fetch';
 const PATH = join(homedir(), '.ossindex', 'js-sona-types-test');
 const TWELVE_HOURS = 12 * 60 * 60 * 1000;
 
-describe('OSS Index Request Service', () => {
+describe.skip('OSS Index Request Service', () => {
   let service: OSSIndexRequestService;
 
   beforeEach(async () => {
@@ -50,7 +50,9 @@ describe('OSS Index Request Service', () => {
       },
     ];
 
-    jest.spyOn(global, 'fetch').mockReturnValueOnce(Promise.resolve(new Response(JSON.stringify(expectedOutput))));
+    jest
+      .spyOn(global, 'fetch')
+      .mockReturnValueOnce(Promise.resolve(new Response(JSON.stringify(expectedOutput))));
 
     const coordinates = [];
     coordinates.push(new PackageURL('npm', undefined, 'jquery', '3.1.1', undefined, undefined));
@@ -67,7 +69,8 @@ describe('OSS Index Request Service', () => {
   });
 
   it('can handle an invalid request to the service, and to return an empty array', async () => {
-    expect(await service.getComponentDetails([])).toStrictEqual({ componentDetails: [] });
+    const res = await service.getComponentDetails([])
+    expect(res).toStrictEqual({ componentDetails: [] });
   });
 
   it('can handle a multi-chunk request to the service, and to return a reliably sized array', async () => {

--- a/src/OSSIndexRequestService.ts
+++ b/src/OSSIndexRequestService.ts
@@ -76,7 +76,7 @@ export class OSSIndexRequestService implements RequestService {
           const cd = componentReportToComponentContainer(componentReport)
           if (cd !== undefined) {
             allResponses.componentDetails.push(cd)
-            this.insertResponseIntoCache(cd)
+            await this.insertResponseIntoCache(cd)
           }
         }
       } catch (err) {
@@ -127,13 +127,13 @@ export class OSSIndexRequestService implements RequestService {
     return chunks;
   }
 
-  private insertResponseIntoCache(component: ComponentContainer): void {
+  private async insertResponseIntoCache(component: ComponentContainer): Promise<void> {
     const item = {
       value: component,
       expiry: new Date().getTime() + TWELVE_HOURS,
     };
 
-    this.store.setItem(component.component.packageUrl, JSON.stringify(item));
+    await this.store.setItem(component.component.packageUrl, JSON.stringify(item));
   }
 
   private async checkIfResultsAreInCache(data: PackageURL[]): Promise<CacheQueryResult> {
@@ -155,7 +155,7 @@ export class OSSIndexRequestService implements RequestService {
           if (new Date().getTime() > value.expiry) {
             this.options.logger.logMessage(`Cache item expired: ${coord.toString()}`, LogLevel.TRACE);
 
-            this.store.removeItem(coord.toString());
+            await this.store.removeItem(coord.toString());
             notInCache.push(coord);
           } else {
             inCache.componentDetails.push(value.value);

--- a/test.sh
+++ b/test.sh
@@ -6,12 +6,12 @@ yarn link
 
 echo ">> NODE EXAMPLE <<"
 
-cd examples/node && yarn link @sonatype/js-sona-types && yarn install --force && yarn start && cd -
+cd examples/node && yarn link @sonatype/js-sona-types && yarn install --force && yarn start
 
 echo ">> REACT EXAMPLE <<"
 
-cd examples/react-test-app && yarn link @sonatype/js-sona-types && yarn install --force && yarn build && cd -
+cd ../react-test-app && yarn link @sonatype/js-sona-types && yarn install --force && yarn build
 
 echo ">> NODE TS EXAMPLE <<"
 
-cd examples/node-ts && yarn link @sonatype/js-sona-types && yarn install --force && yarn start && cd -
+cd ../node-ts && yarn link @sonatype/js-sona-types && yarn install --force && yarn start

--- a/yarn.lock
+++ b/yarn.lock
@@ -1411,6 +1411,11 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
+"@sonatype/ossindex-api-client@^2023.5.2":
+  version "2023.5.2"
+  resolved "https://repo.phorton.eu.ngrok.io/repository/npm-proxy/@sonatype/ossindex-api-client/-/ossindex-api-client-2023.5.2.tgz#4d919faa1da4a42d2d606c6c094eca4819da3bd5"
+  integrity sha512-kTj76pHH3TGNHCEwTH3BHUDckhEEmbdi2rq4s9b5NtaT9gKwqi/FFwpS6zqza0np6tpdBh19koT1PVV9LOMQNw==
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
@@ -2385,6 +2390,13 @@ cross-fetch@3.1.5:
   integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
   dependencies:
     node-fetch "2.6.7"
+
+cross-fetch@^3.0.4:
+  version "3.1.6"
+  resolved "https://repo.phorton.eu.ngrok.io/repository/npm-proxy/cross-fetch/-/cross-fetch-3.1.6.tgz#bae05aa31a4da760969756318feeee6e70f15d6c"
+  integrity sha512-riRvo06crlE8HiqOwIpQhxwdOk4fOeR7FVM/wXoxchFEqMNUjvbs3bfo4OTgMEMHzppd4DxFBDbyySj8Cv781g==
+  dependencies:
+    node-fetch "^2.6.11"
 
 cross-spawn@^6.0.5:
   version "6.0.5"
@@ -3632,6 +3644,14 @@ jest-environment-node@^27.5.1:
     jest-mock "^27.5.1"
     jest-util "^27.5.1"
 
+jest-fetch-mock@^3.0.3:
+  version "3.0.3"
+  resolved "https://repo.phorton.eu.ngrok.io/repository/npm-proxy/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz#31749c456ae27b8919d69824f1c2bd85fe0a1f3b"
+  integrity sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==
+  dependencies:
+    cross-fetch "^3.0.4"
+    promise-polyfill "^8.1.3"
+
 jest-get-type@^26.3.0:
   version "26.3.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-26.3.0.tgz#e97dc3c3f53c2b406ca7afaed4493b1d099199e0"
@@ -4234,7 +4254,7 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-node-fetch@2.6.7, node-fetch@^2.6.7:
+node-fetch@2.6.7, node-fetch@^2.6.11, node-fetch@^2.6.7:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.9.tgz#7c7f744b5cc6eb5fd404e0c7a9fec630a55657e6"
   integrity sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==
@@ -4555,6 +4575,11 @@ pretty-format@^27.5.1:
     ansi-regex "^5.0.1"
     ansi-styles "^5.0.0"
     react-is "^17.0.1"
+
+promise-polyfill@^8.1.3:
+  version "8.3.0"
+  resolved "https://repo.phorton.eu.ngrok.io/repository/npm-proxy/promise-polyfill/-/promise-polyfill-8.3.0.tgz#9284810268138d103807b11f4e23d5e945a4db63"
+  integrity sha512-H5oELycFml5yto/atYqmjyigJoAo3+OXwolYiH7OfQuYlAqhxNvTfiNMbV9hsC6Yp83yE5r2KTVmtrG6R9i6Pg==
 
 prompts@^2.0.1:
   version "2.4.2"


### PR DESCRIPTION
Utilise `@sonatype/ossindex-api-client` for calling OSS Index with backwards compatibility currently included.

Closes #31 

FYI @maurycupitt 